### PR TITLE
Make tonic version wildcard so the resolver use ccd-rust-sdk version

### DIFF
--- a/contracts/my-contract/deploy-scripts/Cargo.toml
+++ b/contracts/my-contract/deploy-scripts/Cargo.toml
@@ -12,4 +12,5 @@ tokio = { version = "1.36", features = ["rt", "macros", "rt-multi-thread"] }
 clap = { version = "4", features = ["derive", "env"] }
 concordium-rust-sdk = "4"
 my-contract = { path = "../" }
-tonic = { version = "0.10", features = ["tls"] }
+# To enable TLS for the Client from concordium-rust-sdk. The version is put as '*' for the resolver to select the same version as the concordium-rust-sdk.
+tonic = { version = "*", features = ["tls"] }


### PR DESCRIPTION
## Purpose

Avoid tracking the `tonic` version explicitly in the deploy-script by making it a wildcard, such that the resolver chooses the version used by `concordium-rust-sdk`.

This might also prevent dependabot from updating it https://github.com/Concordium/concordium-dapp-starter/pull/18